### PR TITLE
docs(README): Add note for `babel-register`

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -28,6 +28,15 @@
       "contributions": [
         "example"
       ]
+    },
+    {
+      "login": "tamouse",
+      "name": "Tamara Temple",
+      "avatar_url": "https://avatars.githubusercontent.com/u/363583?v=3",
+      "profile": "http://tamouse.org",
+      "contributions": [
+        "doc"
+      ]
     }
   ]
 }

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Utilities to help your webpack config be easier to read
 [![downloads][downloads-badge]][npm-stat]
 [![MIT License][license-badge]][LICENSE]
 
-[![All Contributors](https://img.shields.io/badge/all_contributors-2-orange.svg?style=flat-square)](#contributors)
+[![All Contributors](https://img.shields.io/badge/all_contributors-3-orange.svg?style=flat-square)](#contributors)
 [![PRs Welcome][prs-badge]][prs]
 [![Donate][donate-badge]][donate]
 [![Code of Conduct][coc-badge]][coc]
@@ -40,8 +40,11 @@ npm install --save-dev webpack-config-utils
 
 It is expected that you use this in your `webpack.config.js` file.
 
-> Protip: You can name your config file `webpack.config.babel.js` and it'll be automagically transpiled! So you could
-> use ES6 module imports rather than CommonJS requires. But this example will stick to CommonJS because we love you ❤️
+> Protip: You can name your config file `webpack.config.babel.js` and
+> it'll be automagically transpiled! (Make sure you have
+> `babel-register` installed.) So you could use ES6 module imports
+> rather than CommonJS requires. But this example will stick to
+> CommonJS because we love you ❤️
 
 ```javascript
 const webpack = require('webpack')
@@ -123,8 +126,8 @@ a few another helpful utility: [`webpack-combine-loaders`](https://www.npmjs.com
 Thanks goes to these people ([emoji key][emojis]):
 
 <!-- ALL-CONTRIBUTORS-LIST:START - Do not remove or modify this section -->
-| [<img src="https://avatars.githubusercontent.com/u/1500684?v=3" width="100px;"/><br /><sub>Kent C. Dodds</sub>](https://kentcdodds.com)<br />[💻](https://github.com/kentcdodds/webpack-config-utils/commits?author=kentcdodds) [📖](https://github.com/kentcdodds/webpack-config-utils/commits?author=kentcdodds) 💡 🚇 [⚠️](https://github.com/kentcdodds/webpack-config-utils/commits?author=kentcdodds) | [<img src="https://avatars.githubusercontent.com/u/284515?v=3" width="100px;"/><br /><sub>Breno Calazans</sub>](https://twitter.com/breno_calazans)<br />💡 |
-| :---: | :---: |
+| [<img src="https://avatars.githubusercontent.com/u/1500684?v=3" width="100px;"/><br /><sub>Kent C. Dodds</sub>](https://kentcdodds.com)<br />[💻](https://github.com/kentcdodds/webpack-config-utils/commits?author=kentcdodds) [📖](https://github.com/kentcdodds/webpack-config-utils/commits?author=kentcdodds) 💡 🚇 [⚠️](https://github.com/kentcdodds/webpack-config-utils/commits?author=kentcdodds) | [<img src="https://avatars.githubusercontent.com/u/284515?v=3" width="100px;"/><br /><sub>Breno Calazans</sub>](https://twitter.com/breno_calazans)<br />💡 | [<img src="https://avatars.githubusercontent.com/u/363583?v=3" width="100px;"/><br /><sub>Tamara Temple</sub>](http://tamouse.org)<br />[📖](https://github.com/kentcdodds/webpack-config-utils/commits?author=tamouse) |
+| :---: | :---: | :---: |
 <!-- ALL-CONTRIBUTORS-LIST:END -->
 
 This project follows the [all-contributors][all-contributors] specification. Contributions of any kind welcome!


### PR DESCRIPTION
Add a parenthetical comment that to use the "webpack.config.babel.js"
filename, you must have `babel-register` installed.

The convention of specifying babel in the configuration file name is
dependent on the `babel-register` module of Babel. This is explained
somewhat in a StackOverflow comment at:
http://stackoverflow.com/questions/31903692/how-to-use-es6-in-webpack-config/31906902#31906902